### PR TITLE
Deploy book workflow

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -17,12 +17,10 @@ jobs:
         python-version: 3.8
 
     - name: Install dependencies
-      run: |
-        pip install -r requirements.txt
+      run: pip install -r requirements.txt
 
     - name: Build the book
-      run: |
-        jupyter-book build .
+      run: jupyter-book build .
 
     - name: GitHub Pages action
       uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -1,0 +1,31 @@
+name: deploy-book
+
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  deploy-book:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install dependencies
+      run: |
+        pip install -r requirements.txt
+
+    - name: Build the book
+      run: |
+        jupyter-book build .
+
+    - name: GitHub Pages action
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./_build/html


### PR DESCRIPTION
This PR adds a Github action workflow to deploy the book. This workflow is triggered when a commit is pushed to master. Then, the book is built on some Github server and the built content is pushed to the `gh-pages` branch. 

The main advantage is that you no longer keep the book's built version on the main branches. This 1) makes the change history cleaner, since there are no duplicate changes (i.e., source file and book files) and 2) the book doesn't need to be built by someone whenever a change is merged, making e.g., typo fixes and other contributions much more convenient.

(To be discussed on Monday.)